### PR TITLE
添加了发布到本地maven的功能，方便其他app导入

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,4 +84,23 @@ dependencies {
 
     // 仅全量版包含地图模块
     "fullImplementation"(projects.feature.location)
+
+    // // 先运行 ./gradlew publishToMavenLocal
+    // // 然后可以使用本地 Maven 发布的库
+    // val weuiVersion = "2026.01.01"
+    // implementation("top.chengdongqing.weui:core-ui-theme:$weuiVersion")
+    // implementation("top.chengdongqing.weui:core-ui-components:$weuiVersion")
+    // implementation("top.chengdongqing.weui:core-utils:$weuiVersion")
+    // implementation("top.chengdongqing.weui:feature-basic:$weuiVersion")
+    // implementation("top.chengdongqing.weui:feature-form:$weuiVersion")
+    // implementation("top.chengdongqing.weui:feature-media:$weuiVersion")
+    // implementation("top.chengdongqing.weui:feature-feedback:$weuiVersion")
+    // implementation("top.chengdongqing.weui:feature-system:$weuiVersion")
+    // implementation("top.chengdongqing.weui:feature-network:$weuiVersion")
+    // implementation("top.chengdongqing.weui:feature-hardware:$weuiVersion")
+    // implementation("top.chengdongqing.weui:feature-charts:$weuiVersion")
+    // implementation("top.chengdongqing.weui:feature-qrcode:$weuiVersion")
+    // implementation("top.chengdongqing.weui:feature-samples:$weuiVersion")
+
+    // "fullImplementation"("top.chengdongqing.weui:feature-location:$weuiVersion")
 }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -39,5 +39,9 @@ gradlePlugin {
             id = "$prefix.android.room"
             implementationClass = "AndroidRoomConventionPlugin"
         }
+        register("androidMavenPublish") {
+            id = "$prefix.android.maven.publish"
+            implementationClass = "AndroidMavenPublishConventionPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/AndroidMavenPublishConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidMavenPublishConventionPlugin.kt
@@ -1,0 +1,77 @@
+import com.android.build.api.dsl.LibraryExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.findByType
+import org.gradle.kotlin.dsl.get
+
+class AndroidMavenPublishConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        if (target == target.rootProject) {
+            // 在根项目应用时，配置所有符合条件的子项目
+            target.subprojects {
+                val subproject = this
+                subproject.plugins.withId("com.android.library") {
+                    if (shouldPublish(subproject)) {
+                        configureLibraryPublishing(subproject)
+                        subproject.afterEvaluate {
+                            configurePublications(subproject)
+                        }
+                    }
+                }
+            }
+        } else {
+            // 在子项目直接应用时
+            configureLibraryPublishing(target)
+            target.afterEvaluate {
+                configurePublications(target)
+            }
+        }
+    }
+
+    private fun shouldPublish(project: Project): Boolean {
+        val path = project.path
+        // 判断是否属于 core 或 feature 模块
+        return path.startsWith(":core:") || path.startsWith(":feature:")
+    }
+
+    private fun configureLibraryPublishing(project: Project) {
+        project.pluginManager.apply("maven-publish")
+
+        project.extensions.configure<LibraryExtension> {
+            publishing {
+                singleVariant("release") {
+                    withSourcesJar()
+                }
+            }
+        }
+    }
+
+    private fun configurePublications(project: Project) {
+        project.extensions.configure<PublishingExtension> {
+            publications {
+                create<MavenPublication>("release") {
+                    from(project.components["release"])
+
+                    groupId = "top.chengdongqing.weui"
+                    // 将路径转换为 artifactId，如 :core:ui:components -> core-ui-components
+                    artifactId = project.path
+                        .removePrefix(":")
+                        .replace(":", "-")
+                    version = "2026.01.01"
+
+                    pom {
+                        name.set(project.name)
+                        description.set("WeUI Android SDK - ${project.path}")
+                    }
+                }
+            }
+            repositories {
+                mavenLocal()
+            }
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,5 +5,5 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.com.google.devtools.ksp) apply false
     alias(libs.plugins.room) apply false
+    alias(libs.plugins.weui.android.maven.publish)  // 应用发布插件，自动配置所有 core/feature 模块
 }
-true // Needed to make the Suppress annotation work for the plugins block

--- a/feature/location/build.gradle.kts
+++ b/feature/location/build.gradle.kts
@@ -11,9 +11,33 @@ dependencies {
     implementation(libs.navigation.compose)
     implementation(libs.accompanist.permissions)
     implementation(libs.bundles.datastore)
-    implementation(files("${rootProject.projectDir}/libs/AMap3DMap_11.1.060_AMapSearch_9.7.4_AMapLocation_11.1.060_20251229.aar"))
+    // implementation(files("${rootProject.projectDir}/libs/AMap3DMap_11.1.060_AMapSearch_9.7.4_AMapLocation_11.1.060_20251229.aar"))
+    implementation("top.chengdongqing.amap:amap-all:11.1.060")
 
     implementation(projects.core.ui.theme)
     implementation(projects.core.ui.components)
     implementation(projects.core.utils)
+}
+
+
+// 发布高德地图本地 AAR 到 Maven
+publishing {
+    publications {
+        create<MavenPublication>("amap") {
+            groupId = "top.chengdongqing.amap"
+            artifactId = "amap-all"
+            version = "11.1.060"
+            artifact("${rootProject.projectDir}/libs/AMap3DMap_11.1.060_AMapSearch_9.7.4_AMapLocation_11.1.060_20251229.aar")
+        }
+    }
+    repositories {
+        mavenLocal()
+    }
+}
+
+// 强制编译前发布 amap 到本地 Maven
+tasks.configureEach {
+    if (name == "preBuild") {
+        dependsOn("publishAmapPublicationToMavenLocal")
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -100,6 +100,7 @@ room = { id = "androidx.room", version.ref = "room" }
 weui-android-compose-application = { id = "weui.android.compose.application" }
 weui-android-compose-library = { id = "weui.android.compose.library" }
 weui-android-room = { id = "weui.android.room" }
+weui-android-maven-publish = { id = "weui.android.maven.publish" }
 
 [bundles]
 compose-ui = [

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
+        mavenLocal()  // 本地 Maven，用于解析高德 AAR
         google()
         mavenCentral()
     }


### PR DESCRIPTION
你好，我为代码库添加了一个新的插件。可以将core/feature下面的组件发布到MavenLocal，这样子更方便其他的app使用。

希望可以合并到代码中。